### PR TITLE
fix: fix the bot fail to join the voice channel 

### DIFF
--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require("discord.js")
 const { search_song } = require("../api/search_song")
-const { populate_info, assert_channel_play_queue } = require("../helper")
+const { populate_info, assert_channel_play_queue, join_voice_channel } = require("../helper")
 const { play } = require("../player")
 
 module.exports = {
@@ -38,6 +38,9 @@ module.exports = {
       }`
     }
     await interaction.editReply(play_message)
+
+    // always try to join the voice channel since bot might be manually disconnected/diff channel 
+    queue.connection = join_voice_channel(queue, info, interaction)
 
     if (!queue.playing) {
       queue.playing = true

--- a/src/commands/resume.js
+++ b/src/commands/resume.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require("discord.js")
-const { assert_channel_play_queue } = require("../helper")
+const { assert_channel_play_queue, populate_info, join_voice_channel } = require("../helper")
 const { play } = require("../player")
 
 module.exports = {
@@ -7,6 +7,10 @@ module.exports = {
 
   async execute(interaction) {
     let queue = assert_channel_play_queue(interaction)
+    let info = populate_info(interaction)
+
+    // check before queue.playing for manually disconnection/diff channel
+    queue.connection = join_voice_channel(queue, info, interaction)
 
     if (!queue.playing) {
       queue.playing = true

--- a/src/helper.js
+++ b/src/helper.js
@@ -5,6 +5,9 @@ const {
   MAX_MESSAGE_LENGTH,
   MAX_DESCRIPTION_LENGTH,
 } = require("./common")
+const {
+  joinVoiceChannel,
+} = require("@discordjs/voice")
 
 /**
  * Reads the interaction object from discord and parse it into
@@ -54,6 +57,14 @@ const assert_channel_play_queue = (interaction) => {
   }
 
   return interaction.client.queue.get(interaction.guildId)
+}
+
+const join_voice_channel = (queue, info, interaction) => {
+  return joinVoiceChannel({
+    channelId: info.voice_channel_id,
+    guildId: info.server_id,
+    adapterCreator: interaction.guild.voiceAdapterCreator,
+  })
 }
 
 const display_track = (track) => {
@@ -204,6 +215,7 @@ const trim_description = (description) => {
 exports.populate_info = populate_info
 exports.assert_query_res = assert_query_res
 exports.assert_channel_play_queue = assert_channel_play_queue
+exports.join_voice_channel = join_voice_channel
 exports.display_track = display_track
 exports.send_msg_to_text_channel = send_msg_to_text_channel
 exports.parse_lrc = parse_lrc

--- a/src/player.js
+++ b/src/player.js
@@ -2,12 +2,12 @@ const {
   createAudioPlayer,
   AudioPlayerStatus,
   createAudioResource,
-  joinVoiceChannel,
 } = require("@discordjs/voice")
 const {
   assert_channel_play_queue,
   populate_info,
   send_msg_to_text_channel,
+  join_voice_channel,
 } = require("./helper")
 const { get_song_url_by_id } = require("./api/get_song_url_by_id")
 const { API_OK, ERR_UNPAID, ERR_COPYRIGHT } = require("./common")
@@ -51,11 +51,7 @@ const play = async (interaction) => {
   }
 
   // connect to voice channel and subscribe player, it will automatically move to new channel even if connected
-  queue.connection = joinVoiceChannel({
-    channelId: info.voice_channel_id,
-    guildId: info.server_id,
-    adapterCreator: interaction.guild.voiceAdapterCreator,
-  })
+  queue.connection = join_voice_channel(queue, info, interaction)
 
   queue.connection.subscribe(queue.player)
 


### PR DESCRIPTION
The bot will fail to join the voice channel if:
- manually disconnect from the voice channel by admin
- join different voice channel if the caller joins different channel

The fix applies to `play` and `resume` command. Tests passed.