### PR TITLE
feat: 添加了clean指令（含help描述）

### DIFF
--- a/src/features/commands/clean.ts
+++ b/src/features/commands/clean.ts
@@ -1,0 +1,88 @@
+import {
+    type Client,
+    type CommandInteraction,
+    SlashCommandBuilder,
+    PermissionFlagsBits,
+    ChannelType,
+    TextChannel,
+} from "discord.js"
+
+import { logger } from "@/common/utils/logger"
+import type { Command } from "@/core/commands/Command"
+
+const CleanOption = new SlashCommandBuilder()
+  .setName("clean")
+  .setDescription("Cleans a specified number of messages in the current channel")
+  .addIntegerOption((option) =>
+    option
+      .setName("amount")
+      .setDescription("Number of messages to delete (max 99)")
+      .setRequired(true)
+      .setMinValue(1)
+      .setMaxValue(99)
+  )
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
+
+export const Clean: Command = {
+    name: CleanOption.name,
+    description: CleanOption.description,
+    data: CleanOption,
+    run: async (_: Client, interaction: CommandInteraction) => {
+        try {
+            // check the channel type
+            if (!interaction.channel || interaction.channel.type !== ChannelType.GuildText) {
+                await interaction.reply({
+                    content: "❌ This command can only be used in the text channels.",
+                    ephemeral: true,
+                })
+                
+                return
+            
+            }
+
+            const channel = interaction.channel as TextChannel
+            const amount = interaction.options.get("amount")?.value as number
+            
+            // // check amount 
+            // if (amount < 1 || amount > 99) {
+            //     await interaction.reply({
+            //         content: "❌ A maximum of 99 messages can be cleaned at one time.",
+            //         ephemeral: true,
+            //     })
+                
+            //     return
+            // }
+
+            // fetch and delete messages
+            const initialReply = await interaction.reply({
+                content: `Cleaning... This might take a short while...`,
+                fetchReply: true,
+            })
+            
+            // djs can only fetch 100 msg at once. (so 99 + 1 (this interaction)) will be fetched
+            // If extending this command in the future, could count rounds by (amount / 100 | 0 + 1) and delete by loop
+            const fetchMessages = await channel.messages.fetch({ limit: amount + 1 })
+
+            // filter interaction msg out
+            const deleteMessages = fetchMessages.filter(msg => msg.id !== initialReply.id)
+
+            await channel.bulkDelete(deleteMessages, true)
+
+            await initialReply.edit({
+                content: `✅ Successfully cleaned ${fetchMessages.size - 1} messages.`
+            })
+            
+
+        } catch (error: any) {
+            logger.error(interaction, Clean, error)
+
+            if (!interaction.deferred && !interaction.replied) {
+              await interaction.deferReply()  // will not happen if error in bulkDelete stage.
+            }
+      
+            await interaction.followUp({
+              content: `❌ **Error**\n\`\`\`${error}\`\`\``
+            })
+        }
+    }
+}

--- a/src/features/commands/clean.ts
+++ b/src/features/commands/clean.ts
@@ -12,7 +12,7 @@ import type { Command } from "@/core/commands/Command"
 
 const CleanOption = new SlashCommandBuilder()
   .setName("clean")
-  .setDescription("Cleans a specified number of messages in the current channel")
+  .setDescription("清理历史消息")
   .addIntegerOption((option) =>
     option
       .setName("amount")
@@ -27,6 +27,7 @@ export const Clean: Command = {
     name: CleanOption.name,
     description: CleanOption.description,
     data: CleanOption,
+    manual: "清理当前文字频道（输入数量的）历史消息，单次最多可清理99条。",
     run: async (_: Client, interaction: CommandInteraction) => {
         try {
             // check the channel type

--- a/src/features/commands/help.ts
+++ b/src/features/commands/help.ts
@@ -36,7 +36,7 @@ export const Help: Command = {
   data: HelpOption,
   run: async (client: Client, interaction: CommandInteraction) => {
     try {
-      const excludedCommands = ["sudo", "help", "ping"]
+      const excludedCommands = ["sudo", "help"]
       const command = interaction.options.data[0]?.value as string | undefined
 
       const availableCommands = Commands.filter(

--- a/src/features/commands/index.ts
+++ b/src/features/commands/index.ts
@@ -15,6 +15,7 @@ import { Shuffle } from "./shuffle"
 import { Skip } from "./skip"
 import { Sudo } from "./sudo"
 import { User } from "./user"
+import { Clean } from "./clean"
 
 export const Commands: Command[] = [
   Ping,
@@ -32,4 +33,5 @@ export const Commands: Command[] = [
   Sudo,
   Help,
   Pause,
+  Clean,
 ]

--- a/src/features/commands/ping.ts
+++ b/src/features/commands/ping.ts
@@ -10,12 +10,13 @@ import type { Command } from "@/core/commands/Command"
 
 const PingOption = new SlashCommandBuilder()
   .setName("ping")
-  .setDescription("replies with Pong!")
+  .setDescription("回复你一个Pong! 乒乒乓乓!")
 
 export const Ping: Command = {
   name: PingOption.name,
   description: PingOption.description,
   data: PingOption,
+  manual: "查看与Bamboo机器人的网络延时。",
   run: async (_: Client, interaction: CommandInteraction) => {
     try {
       await interaction.reply(


### PR DESCRIPTION
- 256469c: 添加了`clean`指令，使用方式`/clean <amount>` （输入范围1 - 99），感觉够用了。超过99需要多轮，因为`messages.fetch` 和 `bulkDelete` 最多单次支持100条历史消息，感觉足够了已经。如果需要多轮可以看64行的注释，加一个round就行，但感觉没必要。
- ee897b8: 给`clean`和`ping`添加进了指令列表，同时加了manual。