### PR TITLE
Restore voice playback and add crash protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/discordjs"><img src="https://img.shields.io/badge/discord.js-v14.16.3-f7df1e.svg?logo=pnpm" alt="discord.js badge" /></a>
-  <a href="https://discord.gg/yYrT6qfy"><img src="https://img.shields.io/discord/966754695123177554.svg?logo=discord&colorB=7289DA&label=Support&logoColor=FAFAFA" alt="Support server badge"/></a>
+  <a href="https://discord.gg/AFSRqK9fVQ"><img src="https://img.shields.io/discord/966754695123177554.svg?logo=discord&colorB=7289DA&label=Support&logoColor=FAFAFA" alt="Support server badge"/></a>
   <a href="https://www.codefactor.io/repository/github/k27dong/bamboo"><img src="https://img.shields.io/codefactor/grade/github/k27dong/bamboo/master?logo=CodeFactor"  alt="Code quality badge"/></a>
   <a href="https://top.gg/bot/899025207161929768"><img src="https://top.gg/api/widget/servers/899025207161929768.svg"></a>
 </p>
@@ -35,21 +35,23 @@ The official instance of Bamboo is hosted on a server that operates 24/7 with au
 
 Bamboo is actively developed and maintained. If you encounter any bugs or have suggestions, feel free to join the support server and share your feedback!
 
-[Join the Official Discord Server](https://discord.gg/p6F32GejZT)
+[Join the Official Discord Server](https://discord.gg/AFSRqK9fVQ)
 
 ## Development
 
 ### Prerequisites
 
-- [`Node.js`]: Runtime for the project
-- [`pnpm`]: Package manager
+- [`Node.js`]: Runtime for the project (22.12 or newer)
+- [`pnpm`]: Package manager (9 or newer)
 - [`ffmpeg`]: Required for audio processing and streaming
 
 ### Usage
 
 1. `pnpm install`: Install dependencies
 2. create a `.env.development` file in the root directory with the format of `.env.example`, and fill in the required fields
-3. `pnpm dev`: build and run the bot in development mode
+3. `pnpm deploy:dev`: register the slash commands in your development server (once, and again whenever commands change)
+4. `pnpm dev`: build and run the bot in development mode
+5. on the first run, a QR code appears in the terminal: scan it with the NetEase Cloud Music app to log in. The session is saved to `cookies/netease.cookie` and reused afterwards
 
 ## Demo (Sound On)
 

--- a/package.json
+++ b/package.json
@@ -36,14 +36,15 @@
     "check": "tsx src/common/scripts/checkDep.ts"
   },
   "dependencies": {
-    "@discord-player/extractor": "^7.1.0",
+    "@discord-player/extractor": "^7.2.0",
     "@discordjs/opus": "^0.10.0",
-    "@discordjs/voice": "^0.18.0",
+    "@discordjs/voice": "^0.19.1",
+    "@snazzah/davey": "0.1.12",
     "@types/qrcode-terminal": "^0.12.2",
     "NeteaseCloudMusicApi": "^4.25.0",
     "bufferutil": "^4.0.8",
     "chalk": "^5.4.1",
-    "discord-player": "^7.1.0",
+    "discord-player": "^7.2.0",
     "discord-player-youtubei": "^1.4.2",
     "discord.js": "^14.16.3",
     "dotenv": "^16.4.5",
@@ -68,7 +69,7 @@
   },
   "packageManager": "pnpm@10.3.0",
   "engines": {
-    "node": ">=20",
+    "node": ">=22.12",
     "pnpm": ">=9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bamboo",
-  "version": "5.0.5",
+  "version": "5.1.0",
   "private": true,
   "description": "Discord bot embedded with NetEase Music Api (从网易云播放的discord机器人)",
   "homepage": "https://github.com/k27dong/bamboo#readme",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,17 @@ importers:
   .:
     dependencies:
       '@discord-player/extractor':
-        specifier: ^7.1.0
-        version: 7.1.0
+        specifier: ^7.2.0
+        version: 7.2.0
       '@discordjs/opus':
         specifier: ^0.10.0
         version: 0.10.0
       '@discordjs/voice':
-        specifier: ^0.18.0
-        version: 0.18.0(@discordjs/opus@0.10.0)(bufferutil@4.0.8)
+        specifier: ^0.19.1
+        version: 0.19.1(@discordjs/opus@0.10.0)(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(bufferutil@4.0.8)
+      '@snazzah/davey':
+        specifier: 0.1.12
+        version: 0.1.12(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
       '@types/qrcode-terminal':
         specifier: ^0.12.2
         version: 0.12.2
@@ -30,8 +33,8 @@ importers:
         specifier: ^5.4.1
         version: 5.4.1
       discord-player:
-        specifier: ^7.1.0
-        version: 7.1.0(@discord-player/extractor@7.1.0)(mediaplex@1.0.0)(tsx@4.19.2)
+        specifier: ^7.2.0
+        version: 7.2.0(@discord-player/extractor@7.2.0)(mediaplex@1.0.0)(tsx@4.19.2)
       discord-player-youtubei:
         specifier: ^1.4.2
         version: 1.4.2
@@ -43,7 +46,7 @@ importers:
         version: 16.4.5
       openai:
         specifier: ^4.82.0
-        version: 4.82.0(ws@8.18.0(bufferutil@4.0.8))
+        version: 4.82.0(ws@8.19.0(bufferutil@4.0.8))
       qrcode-terminal:
         specifier: ^0.12.0
         version: 0.12.0
@@ -96,20 +99,20 @@ packages:
   '@bufbuild/protobuf@2.2.3':
     resolution: {integrity: sha512-tFQoXHJdkEOSwj5tRIZSPNUuXK3RaR7T1nUrPgbYX1pUbvqqaaZAsfo+NXBPsz5rZMSKVFrgK1WL8Q/MSLvprg==}
 
-  '@discord-player/equalizer@7.1.0':
-    resolution: {integrity: sha512-bF5MRDDcm0BeZbTHMcG3UHdTZKHC7w21iEqrjt89KDzis6qz9oRsRWIG1w0NH3UYSCf1X3jdS/WiKdMqGHmmiA==}
+  '@discord-player/equalizer@7.2.0':
+    resolution: {integrity: sha512-k0mzMC92YrooRrSeT7LAgJNf+ce8VCxXJNDtRXL+Eli0WtUwvv30+Wz1vpIMdcuqEX+HRRDkBnMDY1thL5449A==}
 
-  '@discord-player/extractor@7.1.0':
-    resolution: {integrity: sha512-/ttNFkN0hacSS/KJNcPP8Dvk1W8+QGbdlbtJNIPHO1oBfEMazs6BimokMG5eCVmSLPb2MaWPGKTjhoQzHLlBlw==}
+  '@discord-player/extractor@7.2.0':
+    resolution: {integrity: sha512-S+e1g+A8+VXP3TUbK4CpQdVEFPLHJaJBXDVGypUHjezxWfn8YzbiS7eRdgcebuTw2kYC/bCww5+bDiUdEjxLLA==}
 
-  '@discord-player/ffmpeg@7.1.0':
-    resolution: {integrity: sha512-4pKY6S5AwrM2aUWLklELOljKH1S2M2CN4vcel/15U6OGmg1sCJEWWVxLNvWIek/zH5Ua2yU4EN8gNxzZbjq/pw==}
+  '@discord-player/ffmpeg@7.2.0':
+    resolution: {integrity: sha512-XjBbi+Zpm7dtDE7gf4KLYf53J3PNKk0gDigFt1dvRVJ38WmrUUpqRn0QdrH7CwRJhXfexTimSg71xj7Zn65jWw==}
 
-  '@discord-player/opus@7.1.0':
-    resolution: {integrity: sha512-kQdkiCdyPKiKt+2YRgYfx8ymS8ZesvRZXC5Ok8UUoSYVl658yAxwLPlDrziZnVqcuSvGjnAFTcwAZcU00iuRZg==}
+  '@discord-player/opus@7.2.0':
+    resolution: {integrity: sha512-R6/hdU95o42Xdt/oNVtpi6PLL8FqBVOCLalH3kmpQ42F2adLwA3E9V0qfQcyZuUW7NcVbWfLYevV8rmcj/75lg==}
 
-  '@discord-player/utils@7.1.0':
-    resolution: {integrity: sha512-Glaj91FRoi6GRHLQ+rDZWmWL8GEnnUl1OXotIZ1A66flk/C+p99KZahBdHV9u24QZrU5mL+yqGYxqqIQYf4rxQ==}
+  '@discord-player/utils@7.2.0':
+    resolution: {integrity: sha512-07zpzOXbSKIKwwZxKdj1UznB1MYHFZjrC3mZeggreY21yJzNE+MYeH2ueDRH8V4f9tOR8KGustJc36Qza6+uMQ==}
 
   '@discordjs/builders@1.9.0':
     resolution: {integrity: sha512-0zx8DePNVvQibh5ly5kCEei5wtPBIUbSoE9n+91Rlladz4tgtFbJ36PZMxxZrTEOQ7AHMZ/b0crT/0fCy6FTKg==}
@@ -143,13 +146,22 @@ packages:
     resolution: {integrity: sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==}
     engines: {node: '>=18'}
 
-  '@discordjs/voice@0.18.0':
-    resolution: {integrity: sha512-BvX6+VJE5/vhD9azV9vrZEt9hL1G+GlOdsQaVl5iv9n87fkXjf3cSwllhR3GdaUC8m6dqT8umXIWtn3yCu4afg==}
-    engines: {node: '>=18'}
+  '@discordjs/voice@0.19.1':
+    resolution: {integrity: sha512-XYbFVyUBB7zhRvrjREfiWDwio24nEp/vFaVe6u9aBIC5UYuT7HvoMt8LgNfZ5hOyaCW0flFr72pkhUGz+gWw4Q==}
+    engines: {node: '>=22.12.0'}
 
   '@discordjs/ws@1.1.1':
     resolution: {integrity: sha512-PZ+vLpxGCRtmr2RMkqh8Zp+BenUaJqlS6xhgWKEZcgC/vfHLEzpHtKkB0sl3nZWpwtcKk6YWy+pU3okL2I97FA==}
     engines: {node: '>=16.11.0'}
+
+  '@emnapi/core@1.8.1':
+    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
+  '@emnapi/runtime@1.8.1':
+    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+
+  '@emnapi/wasi-threads@1.1.0':
+    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@esbuild/aix-ppc64@0.23.1':
     resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
@@ -682,6 +694,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -805,6 +823,93 @@ packages:
     resolution: {integrity: sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
+  '@snazzah/davey-android-arm-eabi@0.1.12':
+    resolution: {integrity: sha512-6VC/an+Sx5dI5skb+90rYcIB1jhm48Rl0nDaw0UNT4bz1rMjpVfmmZqeocYXMq96IdbBMlE6OTKGcBm2C3gkQg==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@snazzah/davey-android-arm64@0.1.12':
+    resolution: {integrity: sha512-0Bwd03/JsTFhlPhF4q/LW0RxSzntFpQdhz+TBdFljYSg8IEyA38saPJeTNjpIgDfhAumPzvhCdfS6O5qT8yXDw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@snazzah/davey-darwin-arm64@0.1.12':
+    resolution: {integrity: sha512-lKMV6ITi9BQLt0fx/pAT7M8xcojVK7bryVJGdaW3bq8gABFslS3ti/KzrWabQvhpEV71FZe5mV0UcKHFVaTsZw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@snazzah/davey-darwin-x64@0.1.12':
+    resolution: {integrity: sha512-vXXc/eW/e3TQeb7VsdtrPqs3/22j0aSqiP1ZXmZtDjQRBwgSxwItWYa6sh5MELP2EHB2igNlGzB6Hc0XlbGi4g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@snazzah/davey-freebsd-x64@0.1.12':
+    resolution: {integrity: sha512-G1gas5HrC4Xp3mRY0+OeAqXS6fG2tRgBEc8gQh69Hw4YK9RV9mzQKcmoKMkBM72U1+2C+2u57dolnKKzwozByQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@snazzah/davey-linux-arm-gnueabihf@0.1.12':
+    resolution: {integrity: sha512-97Fujh82r2Ll7dPZeNuoZ3yKfsqycf3c93OWXOo/ThNL/18Onl2Ht4SIvpX6VHhfeS9bDpHJ1lHCaz1b/i5ocw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@snazzah/davey-linux-arm64-gnu@0.1.12':
+    resolution: {integrity: sha512-FWyAOv52cHKDM4BOsmImKKogHFvqNFoXmZcicNJbX3XpVl8Mas88ZoXQ+IA5V+qc9pNtAl1MbWwEZ9JrqAQtbg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@snazzah/davey-linux-arm64-musl@0.1.12':
+    resolution: {integrity: sha512-ptRbLSQxtV6EjXppS5z7qaPDI0NRKhrkJYsTlAjEghmOvlAObozSCYYnMO6nbkt6Ab3+lWqyahClzcRNcD2ouw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@snazzah/davey-linux-x64-gnu@0.1.12':
+    resolution: {integrity: sha512-w86fZvhJn0ErOoAQHt2UbQ95V/cgwvfvQ4GlTPQLCzt58nn+rLlXLgPn90qYlSQrZxFW38rKXwqVOMbm9p+pwQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@snazzah/davey-linux-x64-musl@0.1.12':
+    resolution: {integrity: sha512-LLNnO+hfG41ymeI+O1YHo5/0h3aKaetUNLdkBwpdJsjoyKMXZaeCnB+aHNkkupJCMPmWS0g6iPMCHUOqZSBcTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@snazzah/davey-wasm32-wasi@0.1.12':
+    resolution: {integrity: sha512-MPKFuqYVkDFXheR7qmtEY4FWxQ/ADfgsCojQWHi13sibUqCTR9q2F1LqNn2i9IVh3sh1sxeg87fdFMCH63pl7g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@snazzah/davey-win32-arm64-msvc@0.1.12':
+    resolution: {integrity: sha512-Uf4OYHyfbXpzyaOqIV8/h6kv166Qni5+Bxmc1E/ov4uhhKO8qXbOky8zbVOzu0U4cv5ll3s4IQ8jDAJkx/K75Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@snazzah/davey-win32-ia32-msvc@0.1.12':
+    resolution: {integrity: sha512-nRVbKTsb2ldcPI8D4BDA7P/UeiMEMvR+wYuUMp7H1pRD/3dF2hKo+MzUU+Pn78EhuYA3CWHItiAcS/GsPld67A==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@snazzah/davey-win32-x64-msvc@0.1.12':
+    resolution: {integrity: sha512-AgUA3itPDVkxQq7RIkgE1thCiWePwWjyfOZefBBxGIlMWpRUOSwF4vY9kNLnrScyJcFULdR+Zm8PwiwV8/RKnw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@snazzah/davey@0.1.12':
+    resolution: {integrity: sha512-V+NlX5931RwVamZhhEfZekMdcvXDKdMAmHW1AuGaykVQsNyBOq3bpmGpoKRBDCYgFWKIufJ0Dcg3m4cYhvUy6g==}
+    engines: {node: '>= 10'}
+
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
@@ -813,6 +918,9 @@ packages:
 
   '@top-gg/sdk@3.1.6':
     resolution: {integrity: sha512-qWWYDKAwJHaKaA/5EyLYMzfR76MwCbmKVMSXTPMd9FZFPHuLWJHO+m7Q8dWpWtcnunHa6evRAwlB3p83cht7Ww==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -831,6 +939,9 @@ packages:
 
   '@types/qrcode-terminal@0.12.2':
     resolution: {integrity: sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/ws@8.5.13':
     resolution: {integrity: sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==}
@@ -1233,27 +1344,27 @@ packages:
   discord-api-types@0.37.100:
     resolution: {integrity: sha512-a8zvUI0GYYwDtScfRd/TtaNBDTXwP5DiDVX7K5OmE+DRT57gBqKnwtOC5Ol8z0mRW8KQfETIgiB8U0YZ9NXiCA==}
 
-  discord-api-types@0.37.110:
-    resolution: {integrity: sha512-wVaAJkrSgNRo8nd523qKYPqkClTNHhjKOk/g6265rzHuc7TNS6Ivz06DPW4iZvnhFobbH95hKlgsRf6jcAbtlA==}
-
   discord-api-types@0.37.83:
     resolution: {integrity: sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA==}
 
   discord-api-types@0.37.97:
     resolution: {integrity: sha512-No1BXPcVkyVD4ZVmbNgDKaBoqgeQ+FJpzZ8wqHkfmBnTZig1FcH3iPPersiK1TUIAzgClh2IvOuVUYfcWLQAOA==}
 
+  discord-api-types@0.38.42:
+    resolution: {integrity: sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ==}
+
   discord-player-youtubei@1.4.2:
     resolution: {integrity: sha512-LEE6rnqOVuLwdkAjQC0xc/J4xOmBm2o5UPEZBjSFA1xVthx3y3VbCp4Y83j//OO0LWa/XU5szOQ9LXytISQxcg==}
     hasBin: true
 
-  discord-player@7.1.0:
-    resolution: {integrity: sha512-bnEfvx5Ui0jLQjBw/17q8iYlw9C5aAjLiJ8379GQeF3Ln8ddeKRphAvthlKHBmq48aMySARwSxxL8147kQykyA==}
+  discord-player@7.2.0:
+    resolution: {integrity: sha512-0UCo/IKZjEqkv3DLdEWh2jQ0hyzqaTxm25yCCG3NQpiRfCetaRVPbjdTgo4/4YOdNcZEypIPZtkE6lJxpkbtnA==}
     peerDependencies:
-      '@discord-player/extractor': ^7.1.0
+      '@discord-player/extractor': ^7.2.0
       mediaplex: ^1
 
-  discord-voip@7.1.0:
-    resolution: {integrity: sha512-6aQgI3QUj0Ee5tqaAV+pgBcOrgnkBh5/1UxAqbKMYQinQNs9LEZA7OoCxlWdiJVpVM2c1AxCdqhfryQMvM10+A==}
+  discord-voip@7.2.0:
+    resolution: {integrity: sha512-bteX8XrSSqltsjV13jd6uTr5qVZ+c8yjnx2hV/AhvxgA/9qJ2i43Hkrs4qisw/o94s23Ni3tXXQohvu0EzB4+w==}
 
   discord.js@14.16.3:
     resolution: {integrity: sha512-EPCWE9OkA9DnFFNrO7Kl1WHHDYFXu3CNVFJg63bfU7hVtjZGyhShwZtSBImINQRWxWP2tgo2XI+QhdXx28r0aA==}
@@ -1559,6 +1670,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
@@ -1973,6 +2085,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -1995,8 +2108,8 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
-  node-html-parser@6.1.13:
-    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
+  node-html-parser@7.1.0:
+    resolution: {integrity: sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==}
 
   nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
@@ -2650,6 +2763,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
@@ -2695,24 +2820,24 @@ snapshots:
 
   '@bufbuild/protobuf@2.2.3': {}
 
-  '@discord-player/equalizer@7.1.0': {}
+  '@discord-player/equalizer@7.2.0': {}
 
-  '@discord-player/extractor@7.1.0':
+  '@discord-player/extractor@7.2.0':
     dependencies:
       file-type: 16.5.4
       isomorphic-unfetch: 4.0.2
-      node-html-parser: 6.1.13
+      node-html-parser: 7.1.0
       reverbnation-scraper: 2.0.0
       soundcloud.ts: 0.5.5
       spotify-url-info: 3.2.18
     transitivePeerDependencies:
       - encoding
 
-  '@discord-player/ffmpeg@7.1.0': {}
+  '@discord-player/ffmpeg@7.2.0': {}
 
-  '@discord-player/opus@7.1.0': {}
+  '@discord-player/opus@7.2.0': {}
 
-  '@discord-player/utils@7.1.0':
+  '@discord-player/utils@7.2.0':
     dependencies:
       '@discordjs/collection': 1.5.3
 
@@ -2771,15 +2896,18 @@ snapshots:
 
   '@discordjs/util@1.1.1': {}
 
-  '@discordjs/voice@0.18.0(@discordjs/opus@0.10.0)(bufferutil@4.0.8)':
+  '@discordjs/voice@0.19.1(@discordjs/opus@0.10.0)(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)(bufferutil@4.0.8)':
     dependencies:
-      '@types/ws': 8.5.13
-      discord-api-types: 0.37.110
+      '@snazzah/davey': 0.1.12(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      '@types/ws': 8.18.1
+      discord-api-types: 0.38.42
       prism-media: 1.3.5(@discordjs/opus@0.10.0)
       tslib: 2.8.1
-      ws: 8.18.0(bufferutil@4.0.8)
+      ws: 8.19.0(bufferutil@4.0.8)
     transitivePeerDependencies:
       - '@discordjs/opus'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - bufferutil
       - ffmpeg-static
       - node-opus
@@ -2800,6 +2928,22 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@emnapi/core@1.8.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.8.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.23.1':
     optional: true
@@ -3112,6 +3256,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
+    dependencies:
+      '@emnapi/core': 1.8.1
+      '@emnapi/runtime': 1.8.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3193,6 +3344,73 @@ snapshots:
 
   '@sapphire/snowflake@3.5.3': {}
 
+  '@snazzah/davey-android-arm-eabi@0.1.12':
+    optional: true
+
+  '@snazzah/davey-android-arm64@0.1.12':
+    optional: true
+
+  '@snazzah/davey-darwin-arm64@0.1.12':
+    optional: true
+
+  '@snazzah/davey-darwin-x64@0.1.12':
+    optional: true
+
+  '@snazzah/davey-freebsd-x64@0.1.12':
+    optional: true
+
+  '@snazzah/davey-linux-arm-gnueabihf@0.1.12':
+    optional: true
+
+  '@snazzah/davey-linux-arm64-gnu@0.1.12':
+    optional: true
+
+  '@snazzah/davey-linux-arm64-musl@0.1.12':
+    optional: true
+
+  '@snazzah/davey-linux-x64-gnu@0.1.12':
+    optional: true
+
+  '@snazzah/davey-linux-x64-musl@0.1.12':
+    optional: true
+
+  '@snazzah/davey-wasm32-wasi@0.1.12(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@snazzah/davey-win32-arm64-msvc@0.1.12':
+    optional: true
+
+  '@snazzah/davey-win32-ia32-msvc@0.1.12':
+    optional: true
+
+  '@snazzah/davey-win32-x64-msvc@0.1.12':
+    optional: true
+
+  '@snazzah/davey@0.1.12(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)':
+    optionalDependencies:
+      '@snazzah/davey-android-arm-eabi': 0.1.12
+      '@snazzah/davey-android-arm64': 0.1.12
+      '@snazzah/davey-darwin-arm64': 0.1.12
+      '@snazzah/davey-darwin-x64': 0.1.12
+      '@snazzah/davey-freebsd-x64': 0.1.12
+      '@snazzah/davey-linux-arm-gnueabihf': 0.1.12
+      '@snazzah/davey-linux-arm64-gnu': 0.1.12
+      '@snazzah/davey-linux-arm64-musl': 0.1.12
+      '@snazzah/davey-linux-x64-gnu': 0.1.12
+      '@snazzah/davey-linux-x64-musl': 0.1.12
+      '@snazzah/davey-wasm32-wasi': 0.1.12(@emnapi/core@1.8.1)(@emnapi/runtime@1.8.1)
+      '@snazzah/davey-win32-arm64-msvc': 0.1.12
+      '@snazzah/davey-win32-ia32-msvc': 0.1.12
+      '@snazzah/davey-win32-x64-msvc': 0.1.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   '@tokenizer/token@0.3.0': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
@@ -3201,6 +3419,11 @@ snapshots:
     dependencies:
       raw-body: 2.5.2
       undici: 5.28.5
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/estree@1.0.6': {}
 
@@ -3220,6 +3443,10 @@ snapshots:
       undici-types: 6.20.0
 
   '@types/qrcode-terminal@0.12.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.10.1
 
   '@types/ws@8.5.13':
     dependencies:
@@ -3624,11 +3851,11 @@ snapshots:
 
   discord-api-types@0.37.100: {}
 
-  discord-api-types@0.37.110: {}
-
   discord-api-types@0.37.83: {}
 
   discord-api-types@0.37.97: {}
+
+  discord-api-types@0.38.42: {}
 
   discord-player-youtubei@1.4.2:
     dependencies:
@@ -3636,14 +3863,14 @@ snapshots:
       undici: 7.3.0
       youtubei.js: 13.0.0
 
-  discord-player@7.1.0(@discord-player/extractor@7.1.0)(mediaplex@1.0.0)(tsx@4.19.2):
+  discord-player@7.2.0(@discord-player/extractor@7.2.0)(mediaplex@1.0.0)(tsx@4.19.2):
     dependencies:
-      '@discord-player/equalizer': 7.1.0
-      '@discord-player/extractor': 7.1.0
-      '@discord-player/ffmpeg': 7.1.0
-      '@discord-player/utils': 7.1.0
+      '@discord-player/equalizer': 7.2.0
+      '@discord-player/extractor': 7.2.0
+      '@discord-player/ffmpeg': 7.2.0
+      '@discord-player/utils': 7.2.0
       '@web-scrobbler/metadata-filter': 3.2.0
-      discord-voip: 7.1.0(tsx@4.19.2)
+      discord-voip: 7.2.0(tsx@4.19.2)
       libsodium-wrappers: 0.7.15
       mediaplex: 1.0.0
     transitivePeerDependencies:
@@ -3655,12 +3882,12 @@ snapshots:
       - tsx
       - yaml
 
-  discord-voip@7.1.0(tsx@4.19.2):
+  discord-voip@7.2.0(tsx@4.19.2):
     dependencies:
-      '@discord-player/ffmpeg': 7.1.0
-      '@discord-player/opus': 7.1.0
-      '@discord-player/utils': 7.1.0
-      '@types/ws': 8.5.13
+      '@discord-player/ffmpeg': 7.2.0
+      '@discord-player/opus': 7.2.0
+      '@discord-player/utils': 7.2.0
+      '@types/ws': 8.18.1
       tsup: 8.3.6(tsx@4.19.2)(typescript@5.7.2)
       typescript: 5.7.2
     transitivePeerDependencies:
@@ -4484,7 +4711,7 @@ snapshots:
 
   node-gyp-build@4.8.4: {}
 
-  node-html-parser@6.1.13:
+  node-html-parser@7.1.0:
     dependencies:
       css-select: 5.1.0
       he: 1.2.0
@@ -4518,7 +4745,7 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  openai@4.82.0(ws@8.18.0(bufferutil@4.0.8)):
+  openai@4.82.0(ws@8.19.0(bufferutil@4.0.8)):
     dependencies:
       '@types/node': 18.19.74
       '@types/node-fetch': 2.6.12
@@ -4528,7 +4755,7 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
-      ws: 8.18.0(bufferutil@4.0.8)
+      ws: 8.19.0(bufferutil@4.0.8)
     transitivePeerDependencies:
       - encoding
 
@@ -5116,6 +5343,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.0(bufferutil@4.0.8):
+    optionalDependencies:
+      bufferutil: 4.0.8
+
+  ws@8.19.0(bufferutil@4.0.8):
     optionalDependencies:
       bufferutil: 4.0.8
 

--- a/src/Bamboo.ts
+++ b/src/Bamboo.ts
@@ -12,6 +12,13 @@ import { BambooExtractor } from "@/core/extractor/BambooExtractor"
 import * as playerEvents from "@/core/player/events"
 import * as clientEvents from "@/features/events"
 
+process.on("unhandledRejection", (error) => {
+  console.error("Unhandled rejection:", error)
+})
+process.on("uncaughtException", (error) => {
+  console.error("Uncaught exception:", error)
+})
+
 initializeVersion().catch((error) => {
   console.error("❌ Failed to initialize version:", error)
 })
@@ -46,4 +53,5 @@ client
   })
   .catch((error) => {
     console.error("❌ Failed to log in:", error)
+    setTimeout(() => process.exit(1), 15_000)
   })

--- a/src/core/player/events/error.ts
+++ b/src/core/player/events/error.ts
@@ -1,0 +1,7 @@
+import { type GuildQueue, GuildQueueEvent, type Player } from "discord-player"
+
+export default (player: Player) => {
+  player.events.on(GuildQueueEvent.Error, (_: GuildQueue, error: Error) => {
+    console.error(error)
+  })
+}

--- a/src/core/player/events/index.ts
+++ b/src/core/player/events/index.ts
@@ -1,2 +1,3 @@
+export { default as error } from "./error"
 export { default as playerError } from "./playerError"
 export { default as playerStart } from "./playerStart"


### PR DESCRIPTION
## What this is

The stability work from the July 18 and August 8 production rescues, exactly as it has been running on the server since, plus a README refresh and working support-server links. Production was never redeployed from git, so this brings the repo back in sync with reality.

## Changes

**Voice / DAVE (July 18)**
- discord-player and @discord-player/extractor 7.1.0 -> 7.2.0: Discord made end-to-end encrypted voice (DAVE) mandatory on March 1, 2026, and 7.2.0 is the first release that speaks it. Playback had been dead since that date.
- @snazzah/davey added as a direct dependency: discord-voip requires it at runtime but does not declare it.
- @discordjs/voice 0.18 -> 0.19.1 (this one was already bumped on the server in March; kept).

**Crash protection (August 8)**
- `src/Bamboo.ts`: process-level unhandledRejection / uncaughtException handlers. During the August 6-7 Discord API instability, any failed request inside a handler killed the whole shard (about 14 crash-restarts that week).
- `src/Bamboo.ts`: login failure now exits after 15 seconds so the ShardingManager respawns the process. Previously a swallowed login error left a permanently logged-out zombie shard, which took half the servers offline for roughly 36 hours.
- `src/core/player/events/error.ts` (new): the queue `error` listener discord-player has warned about since July.

**Housekeeping**
- `engines.node` raised to >=22.12 (required by the voice stack).
- README: setup steps now include slash-command registration and the first-run NetEase QR login; prerequisite version floors added.
- README support links fixed: the badge invite was dead and the "official server" link pointed at a different guild ("Ozy Support"). Both now use a fresh permanent invite to Bamboo Support: discord.gg/AFSRqK9fVQ. (The /help command's invites are unrelated: those are minted per-call with a 24h expiry by design; its occasional createInvite crash is on the audit list.)
- Version 5.0.5 -> 5.1.0.

## Verification

- This dependency and source state is what production has been running: since July 18 for the voice stack, since August 8 for the crash protection (2,750 servers, both shards healthy).
- Headless smoke passes on this exact code: the test bot resolves a real NetEase track through BambooExtractor and streams 11+ seconds of DAVE-encrypted audio with zero error events.
- `pnpm install` and `pnpm build:prod` are clean on macOS and Linux.

## Known issue, intentionally not fixed here

- `pnpm type-check` fails with 6 errors: 7.2 narrowed the `requestOptions` type, and bamboo passes its custom `searchType` through it (album/user/lyric commands). Runtime verified unaffected (probed live: searchType still reaches the extractor). The proper fix ships with the dependency-modernization phase.